### PR TITLE
fix [navbar.tsx]: Breadcrumb separator was missing

### DIFF
--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -49,7 +49,7 @@ export default function Navbar() {
                             {formatSegment(segment)}
                           </BreadcrumbLink>
                         </BreadcrumbItem>
-                        {!isLast && <BreadcrumbSeparator />}
+                        {!isLast(index) && <BreadcrumbSeparator />}
                       </React.Fragment>
                     );
                   })


### PR DESCRIPTION
##  Fix: Missing Breadcrumb Separator in Navbar

### 🧩 Summary
This PR fixes a UI bug where the breadcrumb separator (`/`) was missing between navigation items in the `navbar`.
